### PR TITLE
iOS: Ensure onLoad and onLoadEnd get called

### DIFF
--- a/ios/FastImage/FFFastImageView.m
+++ b/ios/FastImage/FFFastImageView.m
@@ -2,6 +2,8 @@
 
 @implementation FFFastImageView {
     BOOL hasSentOnLoadStart;
+    BOOL isComplete;
+    BOOL hasError;
 }
 
 - (void)setResizeMode:(RCTResizeMode)resizeMode
@@ -9,6 +11,20 @@
     if (_resizeMode != resizeMode) {
         _resizeMode = resizeMode;
         self.contentMode = (UIViewContentMode)resizeMode;
+    }
+}
+
+- (void)setOnFastImageLoadEnd:(RCTBubblingEventBlock)onFastImageLoadEnd {
+    _onFastImageLoadEnd = onFastImageLoadEnd;
+    if (isComplete) {
+        _onFastImageLoadEnd(@{});
+    }
+}
+
+- (void)setOnFastImageLoad:(RCTBubblingEventBlock)onFastImageLoad {
+    _onFastImageLoad = onFastImageLoad;
+    if (isComplete && hasError == NO) {
+        _onFastImageLoad(@{});
     }
 }
 
@@ -25,6 +41,9 @@
 
 - (void)setSource:(FFFastImageSource *)source {
     if (_source != source) {
+        isComplete = NO;
+        hasError = NO;
+
         _source = source;
 
         // Set headers.
@@ -70,7 +89,9 @@
                                       NSError * _Nullable error,
                                       SDImageCacheType cacheType,
                                       NSURL * _Nullable imageURL) {
+                            isComplete = YES;
                             if (error) {
+                                hasError = YES;
                                 if (_onFastImageError) {
                                     _onFastImageError(@{});
                                     if (_onFastImageLoadEnd) {


### PR DESCRIPTION
Setting properties from JS to native components does not guarantee any
order (as far as I know). Because of this, `setSource` can get called
and complete before `setOnFastImageLoad` and `setOnFastImageLoadEnd`,
which results in the callbacks never firing.

This change implements a simple check for these callback properties
getting set after the image has loaded, and fires them at that time.